### PR TITLE
V1.0.3更新

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -14,17 +14,13 @@
         "bind_success": {
             "exec_command": false,
             "add_whitelist": true,
-            "comamnds": [
-                "say 玩家#player绑定账号#name（#account）成功"
-            ]
+            "comamnds": ["say 玩家#player绑定账号#name（#account）成功"]
         },
         "un_bind": {
             "kick": true,
             "remove_white_list": true,
             "exec_command": false,
-            "comamnds": [
-                "say 玩家#player解绑了账号。"
-            ]
+            "comamnds": ["say 玩家#player解绑了账号。"]
         },
         "message": {
             "on_at": {
@@ -42,6 +38,8 @@
             }
         }
     },
-    "enable_fake_player_filter": false,  
-    "fake_player_prefix": "bot_"             
+    "bot_filter": {
+        "enabled": false,
+        "prefixes": ["Bot_", "BOT_", "bot_"]
+    }
 }

--- a/easybot_mcdr/config.py
+++ b/easybot_mcdr/config.py
@@ -2,6 +2,8 @@ import json
 import os
 from mcdreforged.api.all import *
 
+config = {}
+
 def load_config(server: PluginServerInterface):
     global config
     server.logger.info("加载配置中...")
@@ -19,6 +21,21 @@ def load_config(server: PluginServerInterface):
         config = json.load(f)
         server.logger.info(f"配置文件路径: {config_file_path}")
         server.logger.info("配置文件加载成功")
+    
+    # 如果缺少 bot_filter，动态添加默认值
+    if "bot_filter" not in config:
+        config["bot_filter"] = {
+            "enabled": True,
+            "prefixes": ["Bot_", "BOT_", "bot_"]
+        }
+        save_config(server)
+
+def save_config(server: PluginServerInterface):
+    config_path = server.get_data_folder()
+    config_file_path = os.path.join(config_path, "config.json")
+    with open(config_file_path, "w", encoding="utf-8", newline='') as f:
+        json.dump(config, f, indent=4, ensure_ascii=False)
+    server.logger.info("配置文件已保存")
 
 def get_config() -> dict:
     return config

--- a/easybot_mcdr/main.py
+++ b/easybot_mcdr/main.py
@@ -1,69 +1,111 @@
-import asyncio
-import re
 from mcdreforged.api.all import *
-from easybot_mcdr.api.player import get_data_map, init_player_api, build_player_info
-from easybot_mcdr.config import get_config, load_config
+from easybot_mcdr.api.player import get_data_map, init_player_api
+from easybot_mcdr.config import get_config, load_config, save_config
 from easybot_mcdr.utils import is_white_list_enable
 from easybot_mcdr.websocket.ws import EasyBotWsClient
-
-import easybot_mcdr.impl
+import re
 
 wsc: EasyBotWsClient = None
 player_data_map = {}
-server_interface: PluginServerInterface = None
-temp_player_list = []  # 临时存储 list 命令解析的玩家
+
+help_msg = '''--------§a EasyBot V1.0.3§r--------
+§b!!ez help §f- §c显示帮助菜单
+§b!!ez reload §f- §c重载配置文件
+
+§c绑定类
+§b!!ez bind §f- §c触发绑定
+§b!!bind §f- §c同上
+
+§c消息发送类
+§b!!ez say <message> §f- §c发送消息
+§b!!esay <message> §f- §c同上
+§b!!say <message> §f- §c同上
+
+§c假人过滤设置(需MCDR 3级权限及以上)
+§b!!ez bot toggle §f- §c开启/关闭假人过滤
+§b!!ez bot add <prefix> §f- §c添加假人过滤前缀
+§b!!ez bot remove <prefix> §f- §c移除假人过滤前缀
+§b!!ez bot list §f- §c显示假人过滤前缀列表
+---------------------------------------------
+'''
+
+
+def is_bot_player(player: str) -> bool:
+    config = get_config()
+    bot_filter = config.get("bot_filter", {"enabled": True, "prefixes": ["Bot_", "BOT_", "bot_"]})
+    if not bot_filter.get("enabled", True):
+        return False
+    prefixes = bot_filter.get("prefixes", ["Bot_", "BOT_", "bot_"])
+    return any(player.startswith(prefix) for prefix in prefixes)
 
 
 async def on_load(server: PluginServerInterface, prev_module):
-    global server_interface, wsc, player_data_map
+    global server_interface
     server_interface = server
 
-    # 如果有之前的模块数据，恢复缓存
     if prev_module is not None and hasattr(prev_module, "player_data_map"):
         init_player_api(server, prev_module.player_data_map)
-        player_data_map = prev_module.player_data_map
     else:
         init_player_api(server, None)
-        # 如果是首次加载或无缓存，同步当前在线玩家
-        await sync_online_players(server)
-    
-    await load(server)
+    await load()
+
     builder = SimpleCommandBuilder()
+    # 定义参数
+    builder.arg("message", Text)  
+    builder.arg("prefix", Text)   
+
+    # 注册命令
+    builder.command("!!ez help", show_help)
+    builder.command("!!ez", show_help)
     builder.command("!!ez reload", reload)
     builder.command("!!ez bind", bind)
     builder.command("!!bind", bind)
-    builder.arg("message", Text)
     builder.command("!!say <message>", say)
     builder.command("!!esay <message>", say)
     builder.command("!!ez say <message>", say)
+
+    # 假人过滤命令
+    builder.command("!!ez bot toggle", toggle_bot_filter)
+    builder.command("!!ez bot add <prefix>", add_bot_prefix)
+    builder.command("!!ez bot remove <prefix>", remove_bot_prefix)
+    builder.command("!!ez bot list", list_bot_prefixes)
+
     builder.register(server)
     server.logger.info("插件加载完成")
 
+    server.register_help_message('!!ez', '显示EasyBot的帮助菜单')
+
+async def show_help(source: CommandSource):
+    for line in help_msg.splitlines():
+        source.reply(line)
 
 async def on_unload(server: PluginServerInterface):
     global player_data_map, wsc
-    player_data_map = get_data_map()  # 保存当前缓存
+    player_data_map = get_data_map()
+    await close()
+    server.logger.info("插件卸载完成")
+
+async def close():
+    global wsc
     if wsc is not None:
         await wsc.stop()
         wsc = None
-    server.logger.info("插件卸载完成")
 
-
-async def load(server: PluginServerInterface):
-    global wsc
-    load_config(server)
+async def load():
+    global wsc, server_interface
+    load_config(server_interface)
     wsc = EasyBotWsClient(get_config()["ws"])
     try:
         await wsc.start()
     except Exception as e:
-        server.logger.error(f"连接失败: {e}")
-        server.logger.error("请检查配置文件ws地址是否正确!")
-
+        server_interface.logger.error(f"连接失败: {e}")
+        server_interface.logger.error("请检查配置文件ws地址是否正确!")
 
 async def bind(source: CommandSource):
     if source.is_console:
         source.reply("§c这个命令不能在控制台使用!")
         return
+
     bind_data = await wsc.get_social_account(source.player)
     if bind_data["uuid"] is None or bind_data["uuid"] == "":
         code = await wsc.start_bind(source.player)
@@ -76,30 +118,21 @@ async def bind(source: CommandSource):
             f"§c你已经绑定了账号, ({bind_data['name']}/{bind_data['uuid']}/时间:{bind_data['time']}/{bind_data['platform']})"
         )
 
-
 async def reload(source: CommandSource):
-    if not source.has_permission(3):
+    if not source.has_permission > 3:
         source.reply(f"§c你没有权限使用这个命令!")
         return
-    await load(server_interface)
+    await load()
     source.reply("§a插件重载成功!")
 
-
 async def say(source: CommandSource, context: CommandContext):
-    global server_interface
-    name = "CONSOLE" if source.is_console else source.player
-    message = context["message"]
-    try:
-        await wsc.push_message(name, message, True)
-        server_interface.say(RText(f"[{name}] {message}", color=RColor.gray))
-        source.reply("§a消息已发送: §f" + message)
-    except Exception as e:
-        server_interface.logger.error(f"消息推送失败: {str(e)}")
-        source.reply("§c消息发送失败，请检查日志！")
-
+    name = "CONSOLE"
+    if source.is_player:
+        name = source.player
+    await wsc.push_message(name, context["message"], True)
+    source.reply("§a消息已发送: §f" + context["message"])
 
 kick_map = []
-
 
 def push_kick(player: str, reason: str):
     if reason is None or reason.strip() == "":
@@ -108,76 +141,112 @@ def push_kick(player: str, reason: str):
     if not server.is_rcon_running():
         server.logger.error("你的服务器RCON当前并未运行,踢出玩家的原因无法显示多行。")
         server.logger.error(f"即将踢出玩家 {player} 并且只显示踢出原因的第一行!")
-        start_line = reason.split("\n")[0]
-        server.execute(f"kick {player} {start_line}")
+        first_line = reason.split("\n")[0]
+        server.execute(f"kick {player} {first_line}")
         return
     global kick_map
     server.rcon_query(f"kick {player} {reason}")
     kick_map.append(player)
 
+async def toggle_bot_filter(source: CommandSource):
+    if not source.has_permission > 3:
+        source.reply("§c你没有权限使用这个命令!")
+        return
+    config = get_config()
+    bot_filter = config.setdefault("bot_filter", {"enabled": True, "prefixes": ["Bot_", "BOT_", "bot_"]})
+    bot_filter["enabled"] = not bot_filter.get("enabled", True)
+    save_config(server_interface)
+    state = "启用" if bot_filter["enabled"] else "禁用"
+    source.reply(f"§a假人过滤已{state}")
 
-async def sync_online_players(server: PluginServerInterface):
-    """同步当前在线玩家到缓存"""
-    from easybot_mcdr.api.player import online_players, cached_data, PlayerInfo
-    global temp_player_list
-    logger = server.logger
-    temp_player_list = []  # 清空临时列表
-    server.execute("list")  # 触发 list 命令
-    await asyncio.sleep(1)  # 等待输出
-    # 同步解析到的玩家
-    for player in temp_player_list:
-        if player not in online_players:
-            uuid = uuid_map.get(player, "unknown-uuid")
-            ip = "127.0.0.1"  # 默认 IP
-            online_players[player] = PlayerInfo(ip, player, uuid)
-            cached_data[player] = online_players[player]
-            logger.info(f"同步在线玩家 {player} 到缓存: UUID={uuid}, IP={ip}")
-    temp_player_list = []  # 重置临时列表
+async def add_bot_prefix(source: CommandSource, context: CommandContext):
+    if not source.has_permission > 3:
+        source.reply("§c你没有权限使用这个命令!")
+        return
+    prefix = context["prefix"]
+    config = get_config()
+    bot_filter = config.setdefault("bot_filter", {"enabled": True, "prefixes": ["Bot_", "BOT_", "bot_"]})
+    prefixes = bot_filter.setdefault("prefixes", ["Bot_", "BOT_", "bot_"])
+    if prefix not in prefixes:
+        prefixes.append(prefix)
+        save_config(server_interface)
+        source.reply(f"§a已添加假人前缀: {prefix}")
+    else:
+        source.reply(f"§c前缀 {prefix} 已存在!")
 
+async def remove_bot_prefix(source: CommandSource, context: CommandContext):
+    if not source.has_permission > 3:
+        source.reply("§c你没有权限使用这个命令!")
+        return
+    prefix = context["prefix"]
+    config = get_config()
+    bot_filter = config.setdefault("bot_filter", {"enabled": True, "prefixes": ["Bot_", "BOT_", "bot_"]})
+    prefixes = bot_filter.setdefault("prefixes", ["Bot_", "BOT_", "bot_"])
+    if prefix in prefixes:
+        prefixes.remove(prefix)
+        save_config(server_interface)
+        source.reply(f"§a已移除假人前缀: {prefix}")
+    else:
+        source.reply(f"§c前缀 {prefix} 不存在!")
+
+async def list_bot_prefixes(source: CommandSource):
+    if not source.has_permission > 3:
+        source.reply("§c你没有权限使用这个命令!")
+        return
+    config = get_config()
+    bot_filter = config.get("bot_filter", {"enabled": True, "prefixes": ["Bot_", "BOT_", "bot_"]})
+    prefixes = bot_filter.get("prefixes", ["Bot_", "BOT_", "bot_"])
+    state = "启用" if bot_filter.get("enabled", True) else "禁用"
+    source.reply(f"§a假人过滤状态: {state}")
+    source.reply("§a假人前缀列表: " + ", ".join(prefixes) if prefixes else "§c无前缀")
 
 async def on_player_joined(server: PluginServerInterface, player: str, info: Info):
-    player_info = build_player_info(player)
-    if player_info.get("type") == "fake":
-        server.logger.info(f"检测到假人 {player}，跳过上报")
-    else:
-        await wsc.report_player(player)
+    try:
+        if is_bot_player(player):
+            ip = "unknown"
+            if match := re.search(r'\d+\.\d+\.\d+\.\d+', info.raw_content):
+                ip = match.group()
+            from easybot_mcdr.api.player import cached_data
+            # 获取 PlayerInfo 对象，如果不存在则使用默认值
+            player_info = cached_data.get(player)
+            uuid = player_info.uuid if player_info else "unknown"
+            server.logger.info(f"假人 {player} 已加入: UUID={uuid}, IP={ip}")
+            return
+
+        player_info = await wsc.report_player(player)
+        if player_info is None:
+            server.logger.warning(f"玩家 {player} 的信息未准备好，可能是数据同步延迟")
+            return
+        server.logger.info(f"玩家 {player} 已加入并缓存: UUID={player_info['player_uuid']}, IP={player_info['ip']}")
         res = await wsc.login(player)
         if res["kick"]:
             push_kick(player, res["kick_message"])
             return
-    await wsc.push_enter(player)
+        await wsc.push_enter(player)
+    except Exception as e:
+        server.logger.error(f"处理玩家 {player} 加入时出错: {e}")
 
-
-async def on_info(server: PluginServerInterface, info: Info):
-    global temp_player_list
+async def on_info(server, info: Info):
     raw = info.raw_content
-    # 解析 list 命令输出
-    if match := re.search(r"There are (\d+) of a max of (\d+) players online: (.*)", raw):
-        player_count = int(match.group(1))
-        if player_count > 0:
-            players = match.group(3).split(", ")
-            temp_player_list.extend(players)
-    # 解析 UUID 输出
+    import re
     if match := re.search(
         r"UUID of player (\w+) is ([0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})",
         raw,
     ):
         name = match.group(1)
+        if is_bot_player(name):
+            server.logger.info(f"检测到假人 {name}，跳过白名单和绑定检查")
+            return
         if is_white_list_enable():
             bind_info = await wsc.get_social_account(name)
             if bind_info["uuid"] is not None and bind_info["uuid"] != "":
                 server.execute("whitelist add " + name)
 
-
 async def on_player_left(server: PluginServerInterface, player: str):
     if player in kick_map:
         kick_map.remove(player)
         return
-    try:
-        await wsc.push_exit(player)
-    except Exception as e:
-        server.logger.error(f"推送玩家离开消息失败 (player: {player}): {str(e)}")
-
+    await wsc.push_exit(player)
 
 async def on_user_info(server: PluginServerInterface, info: Info):
     if info.player is None:
@@ -187,7 +256,4 @@ async def on_user_info(server: PluginServerInterface, info: Info):
         and get_config()["message_sync"]["ignore_mcdr_command"]
     ):
         return
-    try:
-        await wsc.push_message(info.player, info.content, False)
-    except Exception as e:
-        server.logger.error(f"推送玩家消息失败 (player: {info.player}): {str(e)}")
+    await wsc.push_message(info.player, info.content, False)

--- a/easybot_mcdr/meta.py
+++ b/easybot_mcdr/meta.py
@@ -1,2 +1,2 @@
 def get_plugin_version():
-    return "1.0.2"
+    return "1.0.3"

--- a/easybot_mcdr/websocket/ws.py
+++ b/easybot_mcdr/websocket/ws.py
@@ -9,9 +9,8 @@ from easybot_mcdr.config import get_config
 from easybot_mcdr.meta import get_plugin_version
 from easybot_mcdr.websocket.context import ExecContext
 
-
 class SessionInfo:
-    def __init__(self, version: str, system: str, dotnet: str, session_id: str, token: str, interval: int):
+    def __init__(self, version: str, system: str, dotnet: str, session_id:str, token: str, interval: int):
         self.version = version
         self.system = system
         self.dotnet = dotnet
@@ -20,9 +19,8 @@ class SessionInfo:
         self.interval = interval
         self.server_name = None
 
-    @classmethod
-    def from_dict(cls, data: dict):
-        return cls(
+    def from_dict(data: dict):
+        return SessionInfo(
             version=data["version"],
             system=data["system"],
             dotnet=data["dotnet"],
@@ -55,7 +53,6 @@ class SessionInfo:
     def get_server_name(self):
         return self.server_name
 
-
 class EasyBotWsClient:
     _listeners = defaultdict(list)
 
@@ -68,102 +65,118 @@ class EasyBotWsClient:
         return decorator
 
     def __init__(self, url):
-        self.ws_url = url
-        self._conn_lock = asyncio.Lock()  # 连接锁防止重复连接
-        self._ws = None
-        self._active = False
-        self._manual_stop = False
-        self._reconnect_base = 1  # 指数退避基数
-        self._max_reconnect_interval = 30  # 最大重连间隔
-        self._session_info = None
-        self._heartbeat_task = None  # 心跳任务
-        self._connection_task = None  # 连接管理任务
-        self._pending_requests = {}  # 存储等待中的请求 {callback_id: future}
-        self._request_counter = 0    # 用于生成唯一 callback_id
-
-    async def send_and_wait(self, exec_op: str, data: dict, timeout: float = 10.0) -> dict:
-        """
-        发送请求并等待响应
-        """
-        callback_id = f"req_{self._request_counter}"
-        self._request_counter += 1
-
-        loop = asyncio.get_running_loop()
-        future = loop.create_future()
-        self._pending_requests[callback_id] = future
-
-        try:
-            packet = {"op": 4, "exec_op": exec_op, "callback_id": str(callback_id)}
-            packet.update(data)
-            await self.send(json.dumps(packet))
-            return await asyncio.wait_for(future, timeout)
-        finally:
-            self._pending_requests.pop(callback_id, None)
-
-    async def start(self):
-        """启动连接循环"""
-        async with self._conn_lock:
-            if self._active:
-                return
-            self._active = True
+            self.ws_url = url
+            self._conn_lock = asyncio.Lock()
+            self._ws = None
+            self._active = False
             self._manual_stop = False
-            self._connection_task = asyncio.create_task(self._connection_manager())
+            self._reconnect_base = 1
+            self._max_reconnect_interval = 30
+            self._session_info = None
+            self._heartbeat_task = None
+            self._connection_task = None
+            self._pending_requests = {}
+            self._request_counter = 0
+    async def send_and_wait(self, exec_op: str, data: dict, timeout: float = 10.0) -> dict:
+            """
+            发送请求并等待响应
+            :param exec_op: 操作类型
+            :param data: 要发送的数据字典
+            :param timeout: 超时时间(秒)
+            :return: 服务器返回的字典结果
+            """
+            callback_id = f"req_{self._request_counter}"
+            self._request_counter += 1
+
+            # 创建 Future 对象用于等待结果
+            loop = asyncio.get_running_loop()
+            future = loop.create_future()
+            self._pending_requests[callback_id] = future
+
+            try:
+                # 构建请求包
+                packet = {
+                    "op": 4,
+                    "exec_op": exec_op,
+                    "callback_id": str(callback_id)
+                }
+                packet.update(data)  # 合并自定义数据
+                
+                # 发送请求
+                await self.send(json.dumps(packet))
+                
+                # 等待结果或超时
+                return await asyncio.wait_for(future, timeout)
+            finally:
+                # 清理 pending 请求
+                self._pending_requests.pop(callback_id, None)
+    async def start(self):
+            async with self._conn_lock:
+                if self._active:
+                    return
+                self._active = True
+                self._manual_stop = False
+                self._connection_task = asyncio.create_task(self._connection_manager())
 
     async def stop(self):
-        """停止连接循环并清理资源"""
-        self._active = False
-        self._manual_stop = True
-        if self._ws:
-            await self._ws.close(reason="MCDR插件端主动关闭连接")
-        # 取消连接管理任务
-        if self._connection_task and not self._connection_task.done():
-            self._connection_task.cancel()
-            try:
-                await self._connection_task
-            except asyncio.CancelledError:
-                pass
-        # 取消心跳任务
-        if self._heartbeat_task and not self._heartbeat_task.done():
-            self._heartbeat_task.cancel()
-            try:
-                await self._heartbeat_task
-            except asyncio.CancelledError:
-                pass
-        await self._cleanup_connection()
-
+            self._active = False
+            self._manual_stop = True
+        
+            if self._ws and self._ws.state is websockets.State.OPEN:
+                await self._ws.close(reason="MCDR插件端主动关闭连接")
+            self._ws = None
+        
+            if self._heartbeat_task and not self._heartbeat_task.done():
+                self._heartbeat_task.cancel()
+                try:
+                    await self._heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+                self._heartbeat_task = None
+        
+            if self._connection_task and not self._connection_task.done():
+                self._connection_task.cancel()
+                try:
+                    await self._connection_task
+                except asyncio.CancelledError:
+                    pass
+                self._connection_task = None
+        
+            logger = ServerInterface.get_instance().logger
+            logger.info("WebSocket 客户端已停止")
     async def _start_heartbeat(self, interval_seconds: int):
-        """启动心跳循环"""
-        if self._heartbeat_task and not self._heartbeat_task.done():
-            self._heartbeat_task.cancel()
-            try:
-                await self._heartbeat_task
-            except asyncio.CancelledError:
-                pass
+            """启动心跳循环"""
+            if self._heartbeat_task and not self._heartbeat_task.done():
+                self._heartbeat_task.cancel()
+                try:
+                    await self._heartbeat_task
+                except asyncio.CancelledError:
+                    pass
 
-        async def heartbeat_loop():
-            try:
-                while True:
-                    await asyncio.sleep(interval_seconds - 10)
-                    if not (self._active and self._ws and self._ws.state is websockets.State.OPEN):
-                        break
-                    await self.send(json.dumps({"op": 2}))
-            except (ConnectionClosed, asyncio.CancelledError):
-                pass
+            async def heartbeat_loop():
+                try:
+                    while True:
+                        await asyncio.sleep(interval_seconds - 10)  # 减少十秒 因为给的是到期时间，需要在到期之前发送心跳
+                        if not (self._active and self._ws and self._ws.state is websockets.State.OPEN):
+                            break
+                        await self.send(json.dumps({"op": 2}))
+                except (ConnectionClosed, asyncio.CancelledError):
+                    pass
 
-        self._heartbeat_task = asyncio.create_task(heartbeat_loop())
-
+            self._heartbeat_task = asyncio.create_task(heartbeat_loop())
     async def _connection_manager(self):
         """连接生命周期管理器"""
         reconnect_attempts = 0
         while self._active:
             try:
+                # 指数退避计算
                 delay = min(self._reconnect_base * (2 ** reconnect_attempts), 
-                            self._max_reconnect_interval)
+                           self._max_reconnect_interval)
                 await asyncio.sleep(delay)
                 
                 async with websockets.connect(self.ws_url) as websocket:
                     self._ws = websocket
-                    reconnect_attempts = 0
+                    reconnect_attempts = 0  # 重置重连计数器
                     await self.on_open()
                     await self._message_pump()
                     
@@ -172,7 +185,7 @@ class EasyBotWsClient:
                 await self.on_error(f"Connection error: {e} (Attempt {reconnect_attempts})")
             except Exception as e:
                 await self.on_error(f"Unexpected error: {e}")
-                await asyncio.sleep(1)
+                await asyncio.sleep(1)  # 非连接错误短暂等待
 
         await self._cleanup_connection()
 
@@ -181,10 +194,13 @@ class EasyBotWsClient:
         try:
             while self._active and self._ws.state is websockets.State.OPEN:
                 try:
-                    message = await asyncio.wait_for(self._ws.recv(), timeout=1.0)
+                    message = await asyncio.wait_for(
+                        self._ws.recv(), 
+                        timeout=1.0  # 添加超时以定期检查连接状态
+                    )
                     await self.on_message(message)
                 except asyncio.TimeoutError:
-                    continue
+                    continue  # 正常轮询检查
         except ConnectionClosed as e:
             await self.on_close(e.code, e.reason)
 
@@ -205,6 +221,7 @@ class EasyBotWsClient:
 
         await self._ws.send(message)
 
+    # 需要实现的生命周期回调
     async def on_open(self):
         ServerInterface.get_instance().logger.info("已与主程序建立连接。")
 
@@ -226,9 +243,12 @@ class EasyBotWsClient:
                 "server_description": f"MCDR_{ServerInterface.get_instance().get_server_information().version}",
             }))
         elif op == 3:
-            self._session_info.set_server_name(data["server_name"])
-            logger.info(f"身份验证成功,已经成功连接到EasyBot。 [{data['server_name']}]")
-            if self._session_info is not None:
+          self._session_info.set_server_name(
+              data["server_name"]
+          )
+          logger.info(f"身份验证成功,已经成功连接到EasyBot。 [{data['server_name']}]")
+            # 启动心跳
+          if self._session_info is not None:
                 interval = self._session_info.get_interval()
                 await self._start_heartbeat(interval)
         elif op == 4:
@@ -237,29 +257,34 @@ class EasyBotWsClient:
                 ctx = ExecContext(data["callback_id"], data["exec_op"], self)
                 for handler in self._listeners[exec_op]:
                     try:
+                        # 自动处理同步/异步函数
                         if asyncio.iscoroutinefunction(handler):
                             await handler(ctx, data, self._session_info)
                         else:
                             handler(ctx, data, self._session_info)
                     except Exception as e:
                         logger.error(f"处理 exec_op={exec_op} 时出错: {str(e)}")
-        elif op == 5:
+        elif op == 5:  # 新增：处理服务器响应
             callback_id = data.get("callback_id")
             if callback_id and callback_id in self._pending_requests:
                 future = self._pending_requests.pop(callback_id)
+                # 去除 op 字段后作为结果返回
                 result = data.copy()
                 result.pop("op", None)
                 future.set_result(result)
-
     async def on_close(self, code, reason):
         ServerInterface.get_instance().logger.info(f"连接关闭: {code} {reason}")
 
     async def on_error(self, error):
         ServerInterface.get_instance().logger.error(f"遇到错误: {error}")
 
-    async def _send_packet(self, exec_op: str, data: dict):
+    async def _send_packet(self, exec_op:str, data:dict):
         if self._active:
-            packet = {"op": 4, "exec_op": exec_op, "callback_id": "0"}
+            packet = {
+                "op": 4,
+                "exec_op": exec_op,
+                "callback_id": "0"
+            }
             packet.update(data)
             await self.send(json.dumps(packet))
 
@@ -270,39 +295,31 @@ class EasyBotWsClient:
         }, 5)
         return data
 
+# easybot_mcdr\websocket\ws.py
     async def report_player(self, player_name: str):
         from easybot_mcdr.api.player import build_player_info
         info = build_player_info(player_name)
+        if info is None:
+            logger = ServerInterface.get_instance().logger
+            logger.warning(f"无法获取玩家 {player_name} 的信息，跳过报告")
+            return None
         await self._send_packet("REPORT_PLAYER", {
             "player_name": player_name,
             "player_uuid": info["player_uuid"],
-            "player_ip": info["ip"],
+            "player_ip": info["ip"],  # 注意这里的键是 "ip"，而不是 "player_ip"
         })
+        return info
 
-    async def push_message(self, player_name: str, message: str, use_command: bool):
+    async def push_message(self, player_name: str, message: str, use_command:bool):
         from easybot_mcdr.api.player import build_player_info
-        try:
-            info = build_player_info(player_name)
-            info['player_name_raw'] = player_name
-            if info.get("type") == "console":
-                await self._send_packet("SYNC_MESSAGE", {
-                    "player": {
-                        "name": "CONSOLE",
-                        "type": "console",
-                        "player_name_raw": "CONSOLE"
-                    },
-                    "message": f"[Server] {message}",
-                    "use_command": use_command
-                })
-            else:
-                await self._send_packet("SYNC_MESSAGE", {
-                    "player": info,
-                    "message": message,
-                    "use_command": use_command
-                })
-        except Exception as e:
-            logger = ServerInterface.get_instance().logger
-            logger.error(f"推送消息失败 (player: {player_name}): {str(e)}")
+        info = build_player_info(player_name)
+        info['player_name_raw'] = player_name
+
+        await self._send_packet("SYNC_MESSAGE", {
+            "player": info,
+            "message": message,
+            "use_command": use_command
+        })
 
     async def push_death(self, player_name: str, killer: str, message: str):
         from easybot_mcdr.api.player import build_player_info
@@ -330,8 +347,8 @@ class EasyBotWsClient:
         await self._send_packet("SYNC_ENTER_EXIT_MESSAGE", {
             "player": info,
             "is_enter": False
-        })
-
+       })
+        
     async def get_social_account(self, player_name: str):
         resp = await self.send_and_wait("GET_SOCIAL_ACCOUNT", {
             "player_name": player_name

--- a/mcdreforged.plugin.json
+++ b/mcdreforged.plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "easybot_mcdr",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "EasyBot",
     "description": "一款集消息同步、自定义命令、绑定管理、高级权限控制、群组互动、自定义模板支持以及自定义插件支持等全方位功能于一体的服务器管理工具，全方位优化游戏社区体验!",
     "author": "MiuxuE",


### PR DESCRIPTION
V1.0.3 更新内容:

1.升级 版本号升级为1.0.3
2.调整 修改carpet假人过滤方法，新增自定义前缀的设置命令，防止因前缀问题导致的遗漏
3.修复 插件经常性与EasyBot主程序进行重连
4.新增 帮助菜单，使用"!!ez"或"!!ez help"查看

尝试性修复：
1.在重新加载插件后会丢失在线玩家状态导致服务端经常出现"玩家 XXX 不在缓存中，可能已离线或未正确加入"，需玩家重新进服刷新的问题 

暂未修复与目前已知异常:
1.在加入或退出服务器时仍会出现"处理 exec_op=SEND_TO_CHAT 时出错: 'NoneType' object is not iterable"现象 
2.目前跨服聊天无法使用