### PR TITLE
修复权限检查逻辑错误

### DIFF
--- a/easybot_mcdr/main.py
+++ b/easybot_mcdr/main.py
@@ -119,7 +119,7 @@ async def bind(source: CommandSource):
         )
 
 async def reload(source: CommandSource):
-    if not source.has_permission > 3:
+    if source.has_permission(3):
         source.reply(f"§c你没有权限使用这个命令!")
         return
     await load()


### PR DESCRIPTION
修复问题:
1.将错误的权限比较运算符 > 替换为正确的函数调用()